### PR TITLE
fix(#59): correctly parse negative numbers in cleanInteger()

### DIFF
--- a/extension/helpers.js
+++ b/extension/helpers.js
@@ -159,19 +159,20 @@ class AES {
     
     /**
      * Cleans a string of punctuation to returns an integer
-     * @param {string} value - "2,000 AS$" | "2.000 AS$"
-     * @returns {integer} 2000
+     * @param {string} value - "-2,000 AS$" | "2.000 AS$" | "256"
+     * @returns {integer} -2000 | 2000 | 256
      */
     static cleanInteger(value) {
-        value = value.trim()
-        const isCurrency = value.match(/\$$/g)?.length
-        const isNegative = value.match(/^[-]/g)?.length
-
-        // \D matches any character that's not a digit
-        let result = value.replaceAll(/\D+/g, "")
-        if (isNegative) {
-            result = result * -1
-        }
+        // TODO: create separate function for cleaning currency values
+        // value = value.trim()
+        // const isExpectedFormat = Boolean(value.match(/^-?(\d+[.,]?)+ AS\$$/))
+        // 
+        // if (!isExpectedFormat) {
+        //     throw new Error("cleanInteger(): unexpected format for value")
+        // }
+        
+        // Match any character that’s no a digit or a dash
+        const result = value.replaceAll(/[^\d-]/g, "")
         return parseInt(result, 10)
     }
 }

--- a/extension/helpers.js
+++ b/extension/helpers.js
@@ -116,7 +116,7 @@ class AES {
      */
     static getServerDate() {
         const source = document.querySelector(".as-navbar-bottom span:has(.fa-clock-o)").innerText.trim()
-        const sourceAsNumbers = this.cleanInteger(source).toString()
+        const sourceAsNumbers = source.toString().replace(/\D/g, "")
         
         // The source always consists of 12 numbers
         const expectedLength = 12

--- a/extension/helpers.js
+++ b/extension/helpers.js
@@ -159,12 +159,19 @@ class AES {
     
     /**
      * Cleans a string of punctuation to returns an integer
-     * @param {string} "2,000 AS$" | "2.000 AS$"
+     * @param {string} value - "2,000 AS$" | "2.000 AS$"
      * @returns {integer} 2000
      */
     static cleanInteger(value) {
+        value = value.trim()
+        const isCurrency = value.match(/\$$/g)?.length
+        const isNegative = value.match(/^[-]/g)?.length
+
         // \D matches any character that's not a digit
         let result = value.replaceAll(/\D+/g, "")
+        if (isNegative) {
+            result = result * -1
+        }
         return parseInt(result, 10)
     }
 }


### PR DESCRIPTION
Closes #59 

The regex was stripping away vital information; this new version preserves this information when necessary.