### PR TITLE
fix(#53): add Discord to the AES menu

### DIFF
--- a/extension/modules/aes-menu.js
+++ b/extension/modules/aes-menu.js
@@ -59,6 +59,10 @@ class AESMenu {
             href: "https://forums.airlinesim.aero/t/introducing-airlinesim-enhancement-suite-beta/",
             newWindow: true
         },{
+            label: "Discord",
+            href: "https://discord.com/channels/113555701774749696/1249639537450160138",
+            newWindow: true
+        },{
             isDivider: true
         },{
             label: "Support",


### PR DESCRIPTION
Closes #53 

This PR adds Discord to the AES menu under “Community”.

<img width="185" alt="the AES menu now includes Discord" src="https://github.com/ZoeBijl/airlinesim-enhancement-suite/assets/5457769/c93b781b-b720-41e8-b6c2-f1cf57597285">
